### PR TITLE
Update copyright year for 2021

### DIFF
--- a/index.html
+++ b/index.html
@@ -199,7 +199,7 @@
 
   <footer>
     <div class="container">
-      <p>Copyright &copy; 2020 Jaimie Sharp</p>
+      <p>Copyright &copy; 2021 Jaimie Sharp</p>
 
       <p>Website by <a href="https://kerrisharp.com" target="_blank">Kerri Sharp</a></p>
     </div>


### PR DESCRIPTION
Very simple PR - updates the copyright year quoted in the footer:

![image](https://user-images.githubusercontent.com/10532380/105524128-21d0fb00-5cd7-11eb-8304-869408ee9a2a.png)
